### PR TITLE
Update ios_show_vlan_parser.yml

### DIFF
--- a/parsers/ios/ios_show_vlan_parser.yml
+++ b/parsers/ios/ios_show_vlan_parser.yml
@@ -90,4 +90,4 @@ vars:
 keys:
   vlans:
     value: "{{ vlan }}"
-    items: "^(?P<id>\\d+)\\s+(?P<name>\\S+)\\s+(?P<status>[a-z]{4,})\\s*(?P<ports>([A-Za-z]+).+)?"
+    items: "^(?P<id>\\d+)\\s+(?P<name>.+?)\\s+(?P<status>[a-z]{4,})\\s*(?P<ports>([A-Za-z]+).+)?"


### PR DESCRIPTION
Spaces are allowed in VLAN names (in IOS). The parser fails to parse VLANs when the name is "TEST TEST" for example. This is because you match \\S+ which literally excluded spaces from being matched. We need to change this to a general match .+, however, this is greedy so it matches all ending spaces also. By adding ? we make it non greedy.
Now it works:

2    VLAN0002                         active    Gi1/0/27
66   TEST TEST                        active    
67   TEST   TEST                      active    
68   LAST                                active    

parses into

{
                "status": "active",
                "ports": [
                    "GigabitEthernet1/0/27"
                ],
                "name": "VLAN0002",
                "id": 2
            },
            {
                "status": "active",
                "ports": [
                    ""
                ],
                "name": "TEST TEST",
                "id": 66
            },
            {
                "status": "active",
                "ports": [
                    ""
                ],
                "name": "TEST   TEST",
                "id": 67
            },
            {
                "status": "active",
                "ports": [
                    ""
                ],
                "name": "LAST",
                "id": 68
            }